### PR TITLE
enable strict mode

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
          style="width:{{ .InitOpts.Width }};height:{{ .InitOpts.Height }};"></div>
 </div>
 <script type="text/javascript">
+    "use strict";
     let myChart___x__{{ .ChartID }}__x__ = echarts.init(document.getElementById('{{ .ChartID }}'), "{{ .Theme }}");
     let option___x__{{ .ChartID }}__x__ = {
         title: {{ .TitleOpts  }},


### PR DESCRIPTION
fix `Uncaught SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode`