### PR TITLE
Add SymbolSize for scatter series

### DIFF
--- a/charts/series.go
+++ b/charts/series.go
@@ -241,6 +241,9 @@ type singleSeries struct {
 	Center   interface{} `json:"center,omitempty"`
 	Radius   interface{} `json:"radius,omitempty"`
 
+	// Scatter chart
+	SymbolSize float32 `json:"symbolSize,omitempty"`
+
 	// WordCloud chart
 	Shape         string    `json:"shape,omitempty"`
 	SizeRange     []float32 `json:"sizeRange,omitempty"`


### PR DESCRIPTION
Add `SymbolSize` for scatter series.

Example: https://echarts.apache.org/examples/en/editor.html?c=scatter-simple
Doc: https://echarts.apache.org/en/option.html#series-scatter.symbolSize